### PR TITLE
Fix handling mods with a missing array of dependencies.

### DIFF
--- a/FactorioDataWrapper/src/com/demod/factorio/ModInfo.java
+++ b/FactorioDataWrapper/src/com/demod/factorio/ModInfo.java
@@ -54,7 +54,11 @@ public class ModInfo {
 		contact = json.optString("contact", "");
 		homepage = json.optString("homepage", "");
 		description = json.optString("description", "");
-		JSONArray dependenciesJson = json.getJSONArray("dependencies");
+		JSONArray dependenciesJson = json.optJSONArray("dependencies");
+		if (dependenciesJson == null)
+		{
+			dependenciesJson = new JSONArray();
+		}
 		for (int i = 0; i < dependenciesJson.length(); i++) {
 			String depString = dependenciesJson.getString(i);
 			String[] depSplit = depString.split("\\s");


### PR DESCRIPTION
Some mods have an info.json file without a dependencies array.

```
Exception in thread "main" org.json.JSONException: JSONObject["dependencies"] not found.
	at org.json.JSONObject.get(JSONObject.java:471)
	at org.json.JSONObject.getJSONArray(JSONObject.java:618)
	at com.demod.factorio.ModInfo.<init>(ModInfo.java:57)
	at com.demod.factorio.ModLoader$ModZip.<init>(ModLoader.java:85)
	at com.demod.factorio.ModLoader.loadFolder(ModLoader.java:174)
	at com.demod.factorio.FactorioData.initializeDataTable(FactorioData.java:237)
	at com.demod.factorio.FactorioData.getTable(FactorioData.java:215)
	at com.demod.factorio.apps.FactorioWikiMain.main(FactorioWikiMain.java:147)
```

I added a null check to ModInfo.